### PR TITLE
Safely ignore ResizeObserver error

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "build:flow": "echo \"// @flow\n\nexport * from '../src';\" > dist/react-beautiful-dnd.cjs.js.flow",
     "storybook": "start-storybook -p 9002",
     "build-storybook": "build-storybook -c .storybook -o site",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "prepare": "yarn build:clean && yarn build:dist && yarn build:flow"
   },
   "dependencies": {
     "@babel/runtime": "^7.9.2",

--- a/src/view/drag-drop-context/error-boundary.jsx
+++ b/src/view/drag-drop-context/error-boundary.jsx
@@ -51,11 +51,15 @@ export default class ErrorBoundary extends React.Component<Props> {
     const callbacks: AppCallbacks = this.getCallbacks();
 
     if (callbacks.isDragging()) {
-      callbacks.tryAbort();
-      warning(`
-        An error was caught by our window 'error' event listener while a drag was occurring.
-        The active drag has been aborted.
-      `);
+      if (event.message.includes('ResizeObserver loop limit exceeded')) {
+        console.log(event.message);
+      } else {
+        callbacks.tryAbort();
+        warning(`
+          An error was caught by our window 'error' event listener while a drag was occurring.
+          The active drag has been aborted.
+          `);
+      }
     }
 
     const err: ?Error = event.error;

--- a/src/view/drag-drop-context/error-boundary.jsx
+++ b/src/view/drag-drop-context/error-boundary.jsx
@@ -51,9 +51,7 @@ export default class ErrorBoundary extends React.Component<Props> {
     const callbacks: AppCallbacks = this.getCallbacks();
 
     if (callbacks.isDragging()) {
-      if (event.message.includes('ResizeObserver loop limit exceeded')) {
-        console.log(event.message);
-      } else {
+      if !(event.message.includes('ResizeObserver loop limit exceeded')) {
         callbacks.tryAbort();
         warning(`
           An error was caught by our window 'error' event listener while a drag was occurring.


### PR DESCRIPTION
This PR attempts to fix the following issue.

![image](https://user-images.githubusercontent.com/25025366/140904279-a838612c-2cf3-49c3-89c8-e81f6076d90a.png)

Related issues:
- https://github.com/atlassian/react-beautiful-dnd/issues/1548
- https://github.com/atlassian/react-beautiful-dnd/issues/2223