### PR TITLE
Fix incorrect syntax

### DIFF
--- a/src/view/drag-drop-context/error-boundary.jsx
+++ b/src/view/drag-drop-context/error-boundary.jsx
@@ -51,7 +51,7 @@ export default class ErrorBoundary extends React.Component<Props> {
     const callbacks: AppCallbacks = this.getCallbacks();
 
     if (callbacks.isDragging()) {
-      if !(event.message.includes('ResizeObserver loop limit exceeded')) {
+      if (!(event.message.includes('ResizeObserver loop limit exceeded'))) {
         callbacks.tryAbort();
         warning(`
           An error was caught by our window 'error' event listener while a drag was occurring.


### PR DESCRIPTION
This PR addresses incorrect typo JS syntax that was used in https://github.com/gojekfarm/react-beautiful-dnd/pull/1.